### PR TITLE
Updated  to  GIT_TAG v2.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ Set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare(
   serverless-sdk
   GIT_REPOSITORY https://github.com/edgeMicroservice/wasm-serverless-cpp-sdk.git
-  GIT_TAG v1.0.0
+  GIT_TAG v2.0.1
   GIT_PROGRESS TRUE
 )
 


### PR DESCRIPTION
Updated from v1.0.0  to  GIT_TAG v2.0.1